### PR TITLE
[test] Modify test error and update doubly list logic

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mingkim <mingkim@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 11:08:00 by mingkim           #+#    #+#             */
-/*   Updated: 2022/10/05 17:02:46 by mingkim          ###   ########.fr       */
+/*   Updated: 2022/10/07 14:08:54 by mingkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@
 
 typedef enum e_type
 {
-	T_NULL,
+	T_NULL = 1,
 	T_WORD,
 	T_PIPE,
 	T_REDIRECT,
@@ -75,8 +75,8 @@ typedef struct s_btree
 /* in ../src/internal/doublylist/utils.c */
 int				is_list_empty(t_doubly_list *lst);
 void			display_list(t_doubly_list *lst);
-void			switch_type(t_type type);
-t_doubly_node   *find_node(t_doubly_list *lst, char *str);
+t_type			switch_type(t_type type);
+t_doubly_node	*find_node(t_doubly_list *lst, char *str);
 
 /* in ../src/internal/doublylist/delete.c */
 void			delete_one(t_doubly_node *node);

--- a/src/internal/doublylist/create.c
+++ b/src/internal/doublylist/create.c
@@ -6,7 +6,7 @@
 /*   By: mingkim <mingkim@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 15:23:51 by mingkim           #+#    #+#             */
-/*   Updated: 2022/10/05 17:01:42 by mingkim          ###   ########.fr       */
+/*   Updated: 2022/10/07 14:10:25 by mingkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@ t_token	*create_token(t_type type, char *value)
 
 	new = malloc(sizeof(t_token));
 	if (!new)
+		return (NULL);
+	if (switch_type(type) == FALSE)
 		return (NULL);
 	new->type = type;
 	new->value = value;

--- a/src/internal/doublylist/insert.c
+++ b/src/internal/doublylist/insert.c
@@ -6,7 +6,7 @@
 /*   By: mingkim <mingkim@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 16:26:37 by mingkim           #+#    #+#             */
-/*   Updated: 2022/10/05 16:26:48 by mingkim          ###   ########.fr       */
+/*   Updated: 2022/10/07 13:43:42 by mingkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,15 +19,19 @@ int	insert_node(t_doubly_list *lst, t_doubly_node *node)
 		return (FALSE);
 	if (lst->len)
 	{
+		node->prev = lst->header.prev;
 		node->next = lst->header.next;
-		node->prev = &(lst->header);
-		lst->header.next = node;
+		lst->header.prev->next = node;
+		lst->header.next->prev = node;
 	}
 	else
 	{
 		lst->header.next = node;
-		node->prev = &(lst->header);
+		node->next = node;
+		node->prev = node;
 	}
+	lst->header.prev = node;
+	lst->len++;
 	return (TRUE);
 }
 
@@ -36,13 +40,16 @@ int	insert_node_by_index(t_doubly_list *lst, t_doubly_node *node, size_t index)
 	t_doubly_node	*buf;
 	size_t			count;
 
-	if (!lst || is_list_empty(lst))
+	if (!lst || lst->len < index)
 		return (FALSE);
+	if (is_list_empty(lst) || index == lst->len || !index)
+		return (insert_node(lst, node));
 	buf = &lst->header;
 	count = -1;
 	while (++count < index)
 		buf = buf->next;
 	node->prev = buf->prev;
 	node->next = buf;
+	lst->len++;
 	return (TRUE);
 }

--- a/src/internal/doublylist/utils.c
+++ b/src/internal/doublylist/utils.c
@@ -6,7 +6,7 @@
 /*   By: mingkim <mingkim@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 15:35:19 by mingkim           #+#    #+#             */
-/*   Updated: 2022/10/05 16:49:01 by mingkim          ###   ########.fr       */
+/*   Updated: 2022/10/07 14:09:10 by mingkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ void	display_list(t_doubly_list *lst)
 		return ;
 	count = -1;
 	node = lst->header.next;
-	while (++count < lst->len - 1)
+	while (++count < lst->len)
 	{
 		printf("doubly list node, index of %zd\n", count);
 		printf("token value = %s\n", node->token->value);
@@ -37,29 +37,30 @@ void	display_list(t_doubly_list *lst)
 	}
 }
 
-/* 구현이 완료된 함수인지 확인해 주세욥 */
-void	switch_type(t_type type)
+t_type	switch_type(t_type type)
 {
 	if (type == T_NULL)
-		printf("token type = T_NULL\n");
+		return (T_NULL);
 	else if (type == T_WORD)
-		printf("token type = T_WORD\n");
+		return (T_WORD);
 	else if (type == T_PIPE)
-		printf("token type = T_PIPE\n");
+		return (T_PIPE);
 	else if (type == T_REDIRECT)
-		printf("token type = T_REDIRECT\n");
+		return (T_REDIRECT);
 	else if (type == T_DOUBLE_QUOTES)
-		printf("token type = T_DOUBLE_QUOTES\n");
+		return (T_DOUBLE_QUOTES);
+	else
+		return (0);
 }
 
-t_doubly_node   *find_node(t_doubly_list *lst, char *str)
+t_doubly_node	*find_node(t_doubly_list *lst, char *str)
 {
-    t_doubly_node   *node;
+	t_doubly_node	*node;
 
 	node = lst->header.next;
-    while (node != NULL)
+	while (node != NULL)
 	{
-		if (ft_strncmp(node->token->value, str, ft_strlen(node->token->value)) == 0)
+		if (!ft_strncmp(node->token->value, str, ft_strlen(node->token->value)))
 			return (node);
 		node = node->next;
 	}

--- a/test/doublylist/Makefile
+++ b/test/doublylist/Makefile
@@ -6,7 +6,7 @@
 #    By: mingkim <mingkim@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/10/05 11:13:33 by mingkim           #+#    #+#              #
-#    Updated: 2022/10/05 16:53:57 by mingkim          ###   ########.fr        #
+#    Updated: 2022/10/07 12:49:05 by mingkim          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -61,6 +61,7 @@ clean:
 	@echo "\033[92mClean test files...\033[0m"
 	rm -rf $(OBJS)
 	make -C $(DOUBLY_DIR) clean
+	make -C $(LIBFT_DIR) clean
 
 # Make fclean
 fclean: 
@@ -68,6 +69,7 @@ fclean:
 	rm -rf $(OBJS)
 	rm -rf $(NAME)
 	make -C $(DOUBLY_DIR) fclean
+	make -C $(LIBFT_DIR) fclean
 
 # Make re
 re: 

--- a/test/doublylist/main.c
+++ b/test/doublylist/main.c
@@ -16,7 +16,7 @@ static void	_should_display_fail(int rv)
 		printf("\033[92m✔\033[0m");
 }
 
-int main(void)
+int	main(void)
 {
 	printf("\n=======TEST utils.c in doublylist=======\n");
 
@@ -41,12 +41,12 @@ int main(void)
 	printf("\n=======TEST creat.c in doublylist=======\n");
 
 	printf("create_token(): ");
-	_should_display_pass(test_create_token(0, "TEST"));
 	_should_display_pass(test_create_token(1, "TEST"));
 	_should_display_pass(test_create_token(2, "TEST"));
 	_should_display_pass(test_create_token(3, "TEST"));
 	_should_display_pass(test_create_token(4, "TEST"));
-	_should_display_fail(test_create_token(5, "TEST"));
+	_should_display_pass(test_create_token(5, "TEST"));
+	_should_display_fail(test_create_token(6, "TEST"));
 	putchar('\n');
 
 	printf("create_doubly_list(): ");
@@ -54,42 +54,41 @@ int main(void)
 	putchar('\n');
 
 	printf("create_doubly_node(): ");
-	_should_display_pass(test_create_doubly_node(0, "TEST"));
 	_should_display_pass(test_create_doubly_node(1, "TEST"));
 	_should_display_pass(test_create_doubly_node(2, "TEST"));
 	_should_display_pass(test_create_doubly_node(3, "TEST"));
 	_should_display_pass(test_create_doubly_node(4, "TEST"));
+	_should_display_pass(test_create_doubly_node(5, "TEST"));
 	putchar('\n');
 
 	printf("\n=======TEST insert.c in doublylist=======\n");
-	
 	printf("insert_node(): ");
-	_should_display_pass(test_insert_node_empty(0, "TEST"));
 	_should_display_pass(test_insert_node_empty(1, "TEST"));
 	_should_display_pass(test_insert_node_empty(2, "TEST"));
 	_should_display_pass(test_insert_node_empty(3, "TEST"));
 	_should_display_pass(test_insert_node_empty(4, "TEST"));
+	_should_display_pass(test_insert_node_empty(5, "TEST"));
 
-	_should_display_pass(test_insert_node(0, "TEST"));
 	_should_display_pass(test_insert_node(1, "TEST"));
 	_should_display_pass(test_insert_node(2, "TEST"));
 	_should_display_pass(test_insert_node(3, "TEST"));
 	_should_display_pass(test_insert_node(4, "TEST"));
+	_should_display_pass(test_insert_node(5, "TEST"));
 
 	_should_display_pass(test_insert_node_lst_null());
 	_should_display_pass(test_insert_node_node_null());
 	putchar('\n');
 
 	printf("insert_node_by_index(): ");
-	_should_display_fail(test_insert_node_by_index_empty(0, "TEST", 0));
-	_should_display_pass(test_insert_node_by_index_empty(0, "TEST", 1));
-	_should_display_pass(test_insert_node_by_index_empty(0, "TEST", 7));
-	_should_display_pass(test_insert_node_by_index_empty(0, "TEST", 100));
+	_should_display_pass(test_insert_node_by_index_empty(1, "TEST", 0));
+	_should_display_fail(test_insert_node_by_index_empty(1, "TEST", 1));
+	_should_display_fail(test_insert_node_by_index_empty(1, "TEST", 7));
+	_should_display_fail(test_insert_node_by_index_empty(1, "TEST", 100));
 
-	_should_display_fail(test_insert_node_by_index(0, "TEST", 0));
-	_should_display_pass(test_insert_node_by_index(0, "TEST", 1));
-	_should_display_pass(test_insert_node_by_index(0, "TEST", 7));
-	_should_display_pass(test_insert_node_by_index(0, "TEST", 100));
+	_should_display_fail(test_insert_node_by_index(1, "TEST", 0));
+	_should_display_pass(test_insert_node_by_index(1, "TEST", 1));
+	_should_display_pass(test_insert_node_by_index(1, "TEST", 7));
+	_should_display_pass(test_insert_node_by_index(1, "TEST", 100));
 	putchar('\n');
 
 	printf("\n=======TEST read.c in doublylist=======\n");
@@ -106,7 +105,6 @@ int main(void)
 	printf("find_delete(): ");
 	putchar('\n');
 
-	system("leaks testDoublyList");
-
+	system("leaks testDoublyList | grep 'leaks for '");
 	return (0);
 }

--- a/test/doublylist/test_doublylist.h
+++ b/test/doublylist/test_doublylist.h
@@ -33,5 +33,4 @@ int		test_insert_node_by_index(t_type type, char *value, size_t index);
 
 /* in test_delete.c */
 
-
 #endif

--- a/test/doublylist/test_insert.c
+++ b/test/doublylist/test_insert.c
@@ -31,22 +31,25 @@ int test_insert_node(t_type type, char *value)
 	tmp_node = &(lst.header);
 	init_token(&token[0], 0, "TEST00");
 	init_node(&node[0], &token[0]);
-	tmp_node->next = &node[0];
-	node[0].prev = tmp_node;
-	tmp_node = tmp_node->next;
+	tmp = insert_node(&lst, &node[0]);
+	if (tmp == FALSE)
+		return (FALSE);
+	tmp_node = tmp_node->next; // node[0]
+
 	init_token(&token[1], 1, "TEST01");
 	init_node(&node[1], &token[1]);
-	tmp_node->next = &node[1];
-	node[2].prev = tmp_node;
-	tmp_node = tmp_node->next;
+	tmp = insert_node(&lst, &node[1]);
+	if (tmp == FALSE)
+		return (FALSE);
+	tmp_node = tmp_node->next; // node[1]
+
 	init_token(&token[2], type, value);
 	init_node(&node[2], &token[2]);
 	tmp = insert_node(&lst, &node[2]);
 	if (tmp == FALSE)
 		return (FALSE);
-
-	tmp_node = tmp_node->next;
-	if (tmp_node != node || \
+	tmp_node = tmp_node->next; // node[2]
+	if (tmp_node != &node[2] || \
 		lst.len != 3)
 		return (FALSE);
 	return (TRUE);
@@ -60,7 +63,7 @@ int	test_insert_node_lst_null(void)
 
 	init_token(&token, 0, "TEST");
 	init_node(&node, &token);
-	
+
 	tmp = insert_node(NULL, &node);
 	if (tmp == FALSE)
 		return (TRUE);
@@ -73,7 +76,7 @@ int	test_insert_node_node_null(void)
 	int				tmp;
 
 	init_lst(&lst);
-	
+
 	tmp = insert_node(&lst, NULL);
 	if (tmp == FALSE)
 		return (TRUE);
@@ -111,17 +114,19 @@ int test_insert_node_by_index(t_type type, char *value, size_t index)
 	tmp_node = &(lst.header);
 	init_token(&token[0], 0, "TEST00");
 	init_node(&node[0], &token[0]);
-	tmp_node->next = &node[0];
-	node[0].prev = tmp_node;
-	tmp_node = tmp_node->next;
+	tmp = insert_node_by_index(&lst, &node[0], 0);
+	if (tmp == FALSE)
+		return (FALSE);
+
 	init_token(&token[1], 1, "TEST01");
 	init_node(&node[1], &token[1]);
-	tmp_node->next = &node[1];
-	node[2].prev = tmp_node;
-	tmp_node = tmp_node->next;
+	tmp = insert_node_by_index(&lst, &node[1], 1);
+	if (tmp == FALSE)
+		return (FALSE);
+
 	init_token(&token[2], type, value);
 	init_node(&node[2], &token[2]);
-	tmp = insert_node_by_index(&lst, node, index);
+	tmp = insert_node_by_index(&lst, &node[2], 2);
 	if (tmp == FALSE)
 		return (FALSE);
 

--- a/test/doublylist/test_utils.c
+++ b/test/doublylist/test_utils.c
@@ -1,6 +1,6 @@
 #include "test_doublylist.h"
 
-int test_is_list_empty(void)
+int	test_is_list_empty(void)
 {
 	t_doubly_list	lst;
 	int				tmp;
@@ -12,7 +12,7 @@ int test_is_list_empty(void)
 	return (TRUE);
 }
 
-int test_is_not_list_empty(void)
+int	test_is_not_list_empty(void)
 {
 	t_token			token;
 	t_doubly_node	node;
@@ -26,13 +26,14 @@ int test_is_not_list_empty(void)
 	init_node(&node, &token);
 	tmp_node->next = &node;
 	node.prev = tmp_node;
+	lst.len++;
 	tmp = is_list_empty(&lst);
 	if (tmp == FALSE)
 		return (TRUE);
 	return (FALSE);
 }
 
-int test_find_node_empty(char *str)
+int	test_find_node_empty(char *str)
 {
 	t_doubly_list	lst;
 	t_doubly_node	*tmp_node;

--- a/test/doublylist/utils.c
+++ b/test/doublylist/utils.c
@@ -20,7 +20,6 @@ void	init_lst(t_doubly_list *lst)
 
 	init_token(&token, 0, "DUMMY");
 	init_node(&header, &token);
-
 	lst->header = header;
 	lst->len = 0;
 }


### PR DESCRIPTION

- *.c : norminette 부분 부분 처리

- test/doubly/Makefile : LIBFT_DIR/clean, LIBFT_DIR/fclean 추가했습니다. 

- doubly/create.c:
  - create_token : switch_type 함수 이용해서 존재하지 않는 토큰인 경우 NULL 반환하도록 했습니다.
  
- doubly/insert.c:
  - insert_node : header를 dummy로 활용하는 circular의 형태를 갖도록 했습니다. 원소가 추가되면 len 증가를 추가했습니다.
  - insert_node_by_index : index가 길이보다 긴 경우 FALSE를 리턴합니다. lst가 비어있거나, index가 경계선(0, len)에 있는 경우 insert_node를 활용합니다.
  
- doubly/utils.c:
  - switch_type: 들어온 타입을 if 로 검사하여 그대로 반환해줍니다. 없는 타입의 경우 0을 리턴합니다.
  - display_list : 마지막 원소가 출력되지 않던 오류를 수정했습니다.
  
- test/main.c:
  - main:
  - token의 값을 0-4에서 1-5로 조정합니다.
  - insert_node_by_index의 테스트에서 pass와 fail을 반전시켜 테스트합니다.
  
- test/doubly/test_insert.c: insert 변경에 따른 일부 로직 수정했습니다.

- test/doubly/test_utils.c: len 증가 부분 추가했습니다.