### PR TITLE
[executor/builtin]

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -17,22 +17,22 @@
 
 /* in ../src/internal/builtin/ */
 /* cd.c */
-int		builtin_cd(t_list *lst);
+int		builtin_cd(t_list *lst, int out_fd);
 
 /* echo.c */
-int     builtin_echo(t_list *lst);
+int	    builtin_echo(t_list *lst, int out_fd);
 
 /* env.c */
-void	builtin_env(void);
+void	builtin_env(int out_fd);
 
 /* exit.c */
 void    builtin_exit(t_list *lst);
 
 /* export.c */
-int     builtin_export(t_list *lst);
+int     builtin_export(t_list *lst, int out_fd);
 
 /* pwd.c */
-int		builtin_pwd(void);
+int		builtin_pwd(int out_fd);
 
 /* unset.c */
 void	builtin_unset(char *key);

--- a/include/executor.h
+++ b/include/executor.h
@@ -17,7 +17,7 @@
 
 /* executor.c */
 void	init_fd(int fd[]);
-void	executor(t_bintree_node	*root, int in_fd, int out_fd, int dir);
+void	executor(t_bintree_node	*root, int in_fd, int out_fd);
 int		serve_status(char *cmd);
 
 /* and_or.c */
@@ -26,6 +26,10 @@ void	execute_or(t_bintree_node *node);
 
 /* bracket.c */
 int		execute_bracket(t_bintree_node *root, int sup_fd[], int dir);
+
+/* builtin.c */
+int	    check_builtin(t_list *lst);
+int	    execute_builtin(t_list *lst, int out_fd);
 
 /* cammand.c */
 int	    execute_command(t_bintree_node *node, int in_fd, int out_fd);

--- a/include/hashtable.h
+++ b/include/hashtable.h
@@ -26,7 +26,7 @@ void			hash_insert(t_ht_item *new_item, t_hashtable *table);
 /* utils.c */
 char			*get_key_from_env(char *str);
 char			*get_value_from_env(char *env);
-void			display_hashtable(t_hashtable *table);
+void			display_hashtable(t_hashtable *table, int out_fd);
 void			prevent_collision(t_hashtable *table, size_t hash, \
 							t_ht_item *new_item);
 

--- a/src/cmd/main.c
+++ b/src/cmd/main.c
@@ -63,7 +63,7 @@ static void	_run(void)
 		_save_history(input);
 		parser(input);
 		set_heredoc(g_global.tree->root);
-		executor(g_global.tree->root, 0, 1, 0);
+		executor(g_global.tree->root, 0, 1);
 		free(input);
 		_clear_tree(&g_global.tree->root);
 	}

--- a/src/internal/builtin/cd.c
+++ b/src/internal/builtin/cd.c
@@ -39,7 +39,7 @@ static int	_cd_home(char *pwd)
 	return (0);
 }
 
-static int	_cd_prev(char *pwd)
+static int	_cd_prev(char *pwd, int out_fd)
 {
 	char	*oldpwd;
 
@@ -53,7 +53,9 @@ static int	_cd_prev(char *pwd)
 	if (chdir(oldpwd) == 0)
 	{
 		update_value(g_global.envp, "PWD", ft_strdup(oldpwd));
-		update_value(g_global.envp, "OLD", ft_strdup(pwd));
+		update_value(g_global.envp, "OLDPWD", ft_strdup(pwd));
+		ft_putstr_fd(oldpwd, out_fd);
+		ft_putstr_fd("\n", out_fd);
 		free(pwd);
 		return (0);
 	}
@@ -66,7 +68,7 @@ static int	_cd_chdir(char *pwd, char *path)
 	if (chdir(path) == 0)
 	{
 		update_value(g_global.envp, "PWD", ft_strdup(path));
-		update_value(g_global.envp, "OLD", ft_strdup(pwd));
+		update_value(g_global.envp, "OLDPWD", ft_strdup(pwd));
 		free(pwd);
 		return (0);
 	}
@@ -88,7 +90,7 @@ static int	_cd_chdir(char *pwd, char *path)
 
 // return 0 -> 잘 동작
 // return 1 -> 에러 발생
-int	builtin_cd(t_list *lst)
+int	builtin_cd(t_list *lst, int out_fd)
 {
 	char	*path;
 	char	*pwd;
@@ -106,7 +108,7 @@ int	builtin_cd(t_list *lst)
 	if (ft_strcmp(path, "~") == 0)
 		return (_cd_home(pwd));
 	else if (ft_strcmp(path, "-") == 0)
-		return (_cd_prev(pwd));
+		return (_cd_prev(pwd, out_fd));
 	else
 		return (_cd_chdir(pwd, path));
 }

--- a/src/internal/builtin/echo.c
+++ b/src/internal/builtin/echo.c
@@ -26,7 +26,7 @@ static void	_echo_print_quote(char *str, int fd)
 	}
 }
 
-static void	_echo_print(t_list *lst)
+static void	_echo_print(t_list *lst, int out_fd)
 {
 	t_token	*token;
 	char	*value;
@@ -34,16 +34,18 @@ static void	_echo_print(t_list *lst)
 	while (lst)
 	{
 		token = (t_token *) lst->content;
+		if  (token->type <= HERE_DOC && token->type >= INP_RDIR)
+			break ;
 		value = token->value;
 		if (token->type == D_QUOTE || token->type == S_QUOTE)
 		{
-			_echo_print_quote(value, STDOUT_FILENO);
-			ft_putstr_fd(" ", STDOUT_FILENO);
+			_echo_print_quote(value, out_fd);
+			ft_putstr_fd(" ", out_fd);
 		}
 		else
 		{
-			ft_putstr_fd(value, STDOUT_FILENO);
-			ft_putstr_fd(" ", STDOUT_FILENO);
+			ft_putstr_fd(value, out_fd);
+			ft_putstr_fd(" ", out_fd);
 		}
 		lst = lst->next;
 	}
@@ -51,13 +53,13 @@ static void	_echo_print(t_list *lst)
 
 // return 0 -> 잘 동작
 // return 1 -> 에러 발생
-int	builtin_echo(t_list *lst)
+int	builtin_echo(t_list *lst, int out_fd)
 {
 	int		option;
 
 	if (!lst)
 	{
-		ft_putstr_fd("\n", STDIN_FILENO);
+		ft_putstr_fd("\n", out_fd);
 		return (0);
 	}
 	option = 0;
@@ -66,8 +68,8 @@ int	builtin_echo(t_list *lst)
 		option = 1;
 		lst = lst->next;
 	}
-	_echo_print(lst);
+	_echo_print(lst, out_fd);
 	if (!option)
-		ft_putstr_fd("\n", 1);
+		ft_putstr_fd("\n", out_fd);
 	return (0);
 }

--- a/src/internal/builtin/env.c
+++ b/src/internal/builtin/env.c
@@ -12,7 +12,7 @@
 
 #include "minishell.h"
 
-void	builtin_env(void)
+void	builtin_env(int out_fd)
 {
-	display_hashtable(g_global.envp);
+	display_hashtable(g_global.envp, out_fd);
 }

--- a/src/internal/builtin/export.c
+++ b/src/internal/builtin/export.c
@@ -60,7 +60,7 @@ static int	_is_valid_identifier(char *str, int *exit_code)
 	return (FALSE);
 }
 
-int	builtin_export(t_list *lst)
+int	builtin_export(t_list *lst, int out_fd)
 {
 	int		exit_code;
 	char	*data;
@@ -70,7 +70,7 @@ int	builtin_export(t_list *lst)
 	exit_code = 0;
 	if (lst == NULL || ((t_token *) lst->content)->value[0] == '#')
 	{
-		display_hashtable(g_global.envp);
+		display_hashtable(g_global.envp, out_fd);
 		return (0);
 	}
 	while (lst)

--- a/src/internal/builtin/pwd.c
+++ b/src/internal/builtin/pwd.c
@@ -12,7 +12,7 @@
 
 #include "minishell.h"
 
-int	builtin_pwd(void)
+int	builtin_pwd(int out_fd)
 {
 	char	*path;
 
@@ -23,7 +23,7 @@ int	builtin_pwd(void)
 			Failed to get current working directory\n\033[0m", STDERR_FILENO);
 		return (1);
 	}
-	ft_putstr_fd(path, STDIN_FILENO);
+	ft_putstr_fd(path, out_fd);
 	free(path);
 	return (0);
 }

--- a/src/internal/executor/and_or.c
+++ b/src/internal/executor/and_or.c
@@ -16,16 +16,16 @@ void	execute_and(t_bintree_node *node)
 {
 	if (!node->lc)
 		syntax_error("&&");
-	executor(node->lc, 0, 1, 0);
+	executor(node->lc, 0, 1);
 	if (!g_global.status)
-		executor(node->rc, 0, 1, 1);
+		executor(node->rc, 0, 1);
 }
 
 void	execute_or(t_bintree_node *node)
 {
 	if (!node->lc)
 		syntax_error("||");
-	executor(node->lc, 0, 1, 0);
+	executor(node->lc, 0, 1);
 	if (g_global.status)
-		executor(node->rc, 0, 1, 1);
+		executor(node->rc, 0, 1);
 }

--- a/src/internal/executor/builtin.c
+++ b/src/internal/executor/builtin.c
@@ -12,44 +12,44 @@
 
 #include "minishell.h"
 
-// int	check_builtin(t_list *lst)
-// {
-// 	t_token	*token;
-// 	char	*cmd;
+int	check_builtin(t_list *lst)
+{
+	t_token	*token;
+	char	*cmd;
 
-// 	token = (t_token *)lst->content;
-// 	cmd = token->value;
-// 	if (ft_strcmp(cmd, "echo") == 0 || 
-// 		ft_strcmp(cmd, "cd") == 0 || 
-// 		ft_strcmp(cmd, "pwd") == 0 || 
-// 		ft_strcmp(cmd, "export") == 0 || 
-// 		ft_strcmp(cmd, "unset") == 0 || 
-// 		ft_strcmp(cmd, "env") == 0 || 
-// 		ft_strcmp(cmd, "exit") == 0)
-// 		return (TRUE);
-// 	return (FALSE);
-// }
+	token = (t_token *)lst->content;
+	cmd = token->value;
+	if (ft_strcmp(cmd, "echo") == 0 || 
+		ft_strcmp(cmd, "cd") == 0 || 
+		ft_strcmp(cmd, "pwd") == 0 || 
+		ft_strcmp(cmd, "export") == 0 || 
+		ft_strcmp(cmd, "unset") == 0 || 
+		ft_strcmp(cmd, "env") == 0 || 
+		ft_strcmp(cmd, "exit") == 0)
+		return (TRUE);
+	return (FALSE);
+}
 
-// int	execute_builtin(t_list *lst)
-// {
-// 	t_token	*token;
-// 	char	*cmd;
+int	execute_builtin(t_list *lst, int out_fd)
+{
+	t_token	*token;
+	char	*cmd;
 
-// 	token = (t_token *)lst->content;
-// 	cmd = token->value;
-// 	if (ft_strcmp(cmd, "echo") == 0)
-// 		return (builtin_echo(lst->next));
-// 	else if (ft_strcmp(cmd, "cd") == 0)
-// 		return (builtin_cd(lst->next));
-// 	else if (ft_strcmp(cmd, "pwd") == 0)
-// 		return (builtin_pwd());
-// 	else if (ft_strcmp(cmd, "export") == 0)
-// 		return (builtin_export(lst->next));
-// 	else if (ft_strcmp(cmd, "unset") == 0)
-// 		return (builtin_unset(lst->next));
-// 	else if (ft_strcmp(cmd, "env") == 0)
-// 		return (builtin_env());
-// 	else if (ft_strcmp(cmd, "exit") == 0)
-// 		return (builtin_exit(lst->next));
-// 	return (1);
-// }
+	token = (t_token *)lst->content;
+	cmd = token->value;
+	if (ft_strcmp(cmd, "echo") == 0)
+		return (builtin_echo(lst->next, out_fd));
+	else if (ft_strcmp(cmd, "cd") == 0)
+		return (builtin_cd(lst->next, out_fd));
+	else if (ft_strcmp(cmd, "pwd") == 0)
+		return (builtin_pwd(out_fd));
+	else if (ft_strcmp(cmd, "export") == 0)
+		return (builtin_export(lst->next, out_fd));
+	else if (ft_strcmp(cmd, "unset") == 0)
+		builtin_unset(((t_token *)lst->next->content)->value);
+	else if (ft_strcmp(cmd, "env") == 0)
+		builtin_env(out_fd);
+	else if (ft_strcmp(cmd, "exit") == 0)
+		builtin_exit(lst->next);
+	return (1);
+}

--- a/src/internal/executor/command.c
+++ b/src/internal/executor/command.c
@@ -108,7 +108,7 @@ static void	_wait_word_child(int pid, int out_fd, int *status)
 {
 	if (out_fd != 1)
 		close(out_fd);
-	waitpid(pid, status, 0);
+	waitpid(pid, status, WNOHANG);
 }
 
 static	int	_set_in(t_bintree_node *node, int in_fd)
@@ -184,7 +184,13 @@ int	execute_command(t_bintree_node *node, int in_fd, int out_fd)
 		in_fd = _set_in(node, in_fd);
 		out_fd = _set_out(node, out_fd);
 	}
-	printf("in fd: %i\n", in_fd);
+	if (check_builtin(node->token_lst))
+	{
+		p_status = execute_builtin(node->token_lst, out_fd);
+		if (out_fd != 1)
+			close(out_fd);
+		return (p_status);
+	}
 	p_status = 0;
 	pid = fork();
 	if (pid == -1)

--- a/src/internal/executor/executor.c
+++ b/src/internal/executor/executor.c
@@ -13,25 +13,12 @@
 #include "minishell.h"
 
 /* execute by preorder */
-void	init_fd(int fd[])
-{
-	fd[0] = 0;
-	fd[1] = 1;
-}
-
-void	executor(t_bintree_node	*root, int in_fd, int out_fd, int dir)
+void	executor(t_bintree_node	*root, int in_fd, int out_fd)
 {
 	if (!root)
 		return ;
-	// if (root->type == TN_RDIR)
-	// 	execute_redirect(root, fd);
 	if (root->type >= TN_HEREDOC && root->type <= TN_WORD)
-	{
-		if (dir == 0)
-			execute_command(root, in_fd, out_fd);
-		else if (dir == 1)
-			execute_command(root, in_fd, out_fd);
-	}
+		execute_command(root, in_fd, out_fd);
 	// else if (root->type == TN_BRACKET)
 	// 	g_global.status = execute_bracket(root, sup_fd, dir);
 	else if (root->type == TN_AND)

--- a/src/internal/executor/pipe.c
+++ b/src/internal/executor/pipe.c
@@ -66,9 +66,9 @@ void	execute_pipe(t_bintree_node	*node, int in_fd, int out_fd)
 	if (pipe(node->fd) == -1)
 		exit_error("pipe error\n");
 	if (node->lc)
-		executor(node->lc, in_fd, node->fd[1], 0);
+		executor(node->lc, in_fd, node->fd[1]);
 	if (node->rc)
-		executor(node->rc, node->fd[0], out_fd, 1);
+		executor(node->rc, node->fd[0], out_fd);
 }
 
 static void	_here_doc(t_bintree_node *node)

--- a/src/internal/hashtable/utils.c
+++ b/src/internal/hashtable/utils.c
@@ -62,7 +62,7 @@ void	prevent_collision(t_hashtable *table, size_t hash, \
 	table->count++;
 }
 
-void	display_hashtable(t_hashtable *table)
+void	display_hashtable(t_hashtable *table, int out_fd)
 {
 	size_t			idx;
 	t_ht_item		*item;
@@ -73,10 +73,10 @@ void	display_hashtable(t_hashtable *table)
 		item = table->items[idx];
 		while (item != NULL)
 		{
-			ft_putstr_fd(item->key, STDOUT_FILENO);
-			ft_putstr_fd("=", STDOUT_FILENO);
-			ft_putstr_fd(item->value, STDOUT_FILENO);
-			ft_putstr_fd("\n", STDOUT_FILENO);
+			ft_putstr_fd(item->key, out_fd);
+			ft_putstr_fd("=", out_fd);
+			ft_putstr_fd(item->value, out_fd);
+			ft_putstr_fd("\n", out_fd);
 			item = item->next;
 		}
 		idx++;


### PR DESCRIPTION
builtin-command 연결
- execute_command 함수 내부에서 builtin 체크 후 execute_builtin로 연결
- builtin 함수 중 출력이 있는 함수에 인자로 out_fd 추가: echo, pwd, export, env
- display_hashtable에도 out_fd 추가 기타 수정 사항
- executor에 dir 인자 삭제